### PR TITLE
Allow Host and Port to be configured for the client and globally

### DIFF
--- a/lib/gap_intelligence.rb
+++ b/lib/gap_intelligence.rb
@@ -2,6 +2,8 @@ require 'gap_intelligence/version'
 
 require 'oauth2'
 
+require 'uri'
+
 require 'gap_intelligence/configuration'
 require 'gap_intelligence/models/record'
 require 'gap_intelligence/models/download'

--- a/lib/gap_intelligence/client.rb
+++ b/lib/gap_intelligence/client.rb
@@ -9,11 +9,15 @@ module GapIntelligence
     attr_reader :connection
 
     attr_accessor :client_id,
-                  :client_secret
+                  :client_secret,
+                  :host,
+                  :port
 
-    def initialize(client_id = nil, client_secret = nil)
-      @client_id = client_id || GapIntelligence.config.client_id
-      @client_secret = client_secret || GapIntelligence.config.client_secret
+    def initialize(config = {})
+      @client_id = config[:client_id]          || GapIntelligence.config.client_id
+      @client_secret = config[:client_secret] || GapIntelligence.config.client_secret
+      @host = config[:host]                   || GapIntelligence.config.host
+      @port = config[:port]                   || GapIntelligence.config.port
     end
 
     # Returns the current connection to gAPI. If the connection is old or
@@ -40,7 +44,7 @@ module GapIntelligence
       raise ConfigurationError unless client_id && client_secret
 
       begin
-        OAuth2::Client.new(client_id, client_secret, site: 'http://api.gapintelligence.com')
+        OAuth2::Client.new(client_id, client_secret, site: api_base_uri)
                       .client_credentials
                       .get_token({}, 'auth_scheme' => 'request_body')
       rescue OAuth2::Error
@@ -55,6 +59,10 @@ module GapIntelligence
       {
         'Accept' => 'application/vnd.gapintelligence.com; version=1'
       }
+    end
+
+    def api_base_uri
+      URI::HTTP.build(host: host, port: port)
     end
   end
 end

--- a/lib/gap_intelligence/configuration.rb
+++ b/lib/gap_intelligence/configuration.rb
@@ -13,6 +13,13 @@ module GapIntelligence
   end
 
   class Configuration
-    attr_accessor :client_id, :client_secret
+    attr_accessor :client_id,
+                  :client_secret,
+                  :host,
+                  :port
+
+    def initialize
+      @host = 'api.gapintelligence.com'
+    end
   end
 end

--- a/spec/gap/client/downloads_spec.rb
+++ b/spec/gap/client/downloads_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe GapIntelligence::Downloads do
   before { stub_api_auth('CLIENTID', 'ASECRET') }
-  subject(:client) { GapIntelligence::Client.new('CLIENTID', 'ASECRET') }
+  subject(:client) { GapIntelligence::Client.new(client_id: 'CLIENTID', client_secret: 'ASECRET') }
 
   describe '#downloads' do
     before { stub_api_request(:get, response: { data: build_list(:download, 3) }) }

--- a/spec/gap/client/requestable_spec.rb
+++ b/spec/gap/client/requestable_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe GapIntelligence::Requestable do
   before { stub_api_auth('CLIENTID', 'ASECRET') }
-  subject(:client) { GapIntelligence::Client.new('CLIENTID', 'ASECRET') }
+  subject(:client) { GapIntelligence::Client.new(client_id: 'CLIENTID', client_secret: 'ASECRET') }
 
   describe '#perform_request' do
     it 'requests path' do

--- a/spec/gap/client_spec.rb
+++ b/spec/gap/client_spec.rb
@@ -21,6 +21,24 @@ describe Client do
       end
     end
 
+    context 'configuring the base URI' do
+      it 'accepts a host' do
+        client.host = 'example.com'
+        expect(client.host).to eq('example.com')
+      end
+
+      it 'accepts a port' do
+        client.host = 3000
+        expect(client.host).to eq(3000)
+      end
+
+      it 'reflects the port and host in the base URI' do
+        client.host = 'localhost'
+        client.port = 3000
+        expect(client.api_base_uri).to eq URI('http://localhost:3000')
+      end
+    end
+
     context 'with shared config' do
       before {
         GapIntelligence.configure do |c|
@@ -30,6 +48,10 @@ describe Client do
       }
 
       after { GapIntelligence.reset_config! }
+
+      it 'defaults to the production gap api' do
+        expect(client.host).to eq('api.gapintelligence.com')
+      end
 
       it 'uses shared config if credentials not provided' do
         expect(client.client_id).to eq('CLIENTID')
@@ -55,7 +77,7 @@ describe Client do
   end
 
   context 'Authenticating a client' do
-    subject(:client) { described_class.new('CLIENTID', 'ASECRET') }
+    subject(:client) { described_class.new(client_id: 'CLIENTID', client_secret: 'ASECRET') }
 
     it 'will authenticate API calls if it provided with valid credentials' do
         stub_api_auth('CLIENTID', 'ASECRET')


### PR DESCRIPTION
There are many instances where we would like to have clients
pointed at different versions of our api.

For example, to test something locally one might want to:

`g = GapIntelligence::Client.new host: 'localhost', port: 3000`

This patch allows this by adding configuartion parameters for
host and port.
