### PR TITLE
Make owner id required param for downloads

### DIFF
--- a/lib/gap_intelligence/client/downloads.rb
+++ b/lib/gap_intelligence/client/downloads.rb
@@ -4,27 +4,29 @@ module GapIntelligence
 
     # Creates new download
     #
+    # @param owner_id [String,Integer] owner id of the download
     # @param params [Hash] parameters that will be the JSON payload of the http request
     # @param options [Hash] options the options to make the request with
     # @yield [request] The Faraday request
     # @return [Download] the created download
     # @return [RequestError] error messages
     # @see http://api.gapintelligence.com/api/doc/v1/downloads/create.html
-    def create_download(params, options = {}, &block)
+    def create_download(owner_id, params, options = {}, &block)
       default_option(options, :record_class, Download)
-      perform_request(:post, 'downloads', options.merge(body: { download: params }), &block)
+      perform_request(:post, 'downloads', options.merge(body: { owner_id: owner_id, download: params }), &block)
     end
 
     # Requests and returns downloads
     #
+    # @param owner_id [String,Integer] owner id of the downloads
     # @param params [Hash] parameters of the http request
     # @param options [Hash] options for the http request
     # @yield [request] The Faraday request
     # @return [RecordSet<Download>] collection of downloads
     # @see http://api.gapintelligence.com/api/doc/v1/downloads/index.html
-    def downloads(params = {}, options = {}, &block)
+    def downloads(owner_id, params = {}, options = {}, &block)
       default_option(options, :record_class, Download)
-      perform_request(:get, 'downloads', options.merge(params: params), &block)
+      perform_request(:get, 'downloads', options.merge(params: params.merge(owner_id: owner_id)), &block)
     end
   end
 end

--- a/spec/gap/client/downloads_spec.rb
+++ b/spec/gap/client/downloads_spec.rb
@@ -5,14 +5,15 @@ describe GapIntelligence::Downloads do
   subject(:client) { GapIntelligence::Client.new(client_id: 'CLIENTID', client_secret: 'ASECRET') }
 
   describe '#create_downloads' do
-    let(:params){ { owner_id: '1', filter: { categories: ['Category 1'], countries: ['Country 1'] } } }
+    let(:owner_id) { 1 }
+    let(:params){ { filter: { categories: ['Category 1'], countries: ['Country 1'] } } }
     before { stub_api_request(:post, url: 'downloads', response: { data: build(:download) }) }
-    subject(:result) { client.create_download(params) }
+    subject(:result) { client.create_download(owner_id, params) }
 
     it 'requests the endpoint' do
-      client.create_download(params)
+      client.create_download(owner_id, params)
 
-      expect(api_post('/downloads').with(body: { download: params })).to have_been_made
+      expect(api_post('/downloads').with(body: { owner_id: owner_id.to_s, download: params })).to have_been_made
     end
 
     it 'creates a new download' do
@@ -28,12 +29,13 @@ describe GapIntelligence::Downloads do
   end
 
   describe '#downloads' do
+    let(:owner_id) { 1 }
     before { stub_api_request(:get, response: { data: build_list(:download, 3) }) }
-    subject(:record_set) { client.downloads }
+    subject(:record_set) { client.downloads(owner_id) }
 
     it 'requests the endpoint' do
-      client.downloads
-      expect(api_get('/downloads')).to have_been_made
+      client.downloads(owner_id)
+      expect(api_get(format('/downloads?owner_id=%i', owner_id))).to have_been_made
     end
 
     it 'returns record set' do


### PR DESCRIPTION
This pull request makes `owner_id` as required param and fixes an issue with creating download on gapi side.