### PR TITLE
Ability to pass scopes to client

### DIFF
--- a/lib/gap_intelligence/client.rb
+++ b/lib/gap_intelligence/client.rb
@@ -17,13 +17,15 @@ module GapIntelligence
     attr_accessor :client_id,
                   :client_secret,
                   :host,
-                  :port
+                  :port,
+                  :scope
 
     def initialize(config = {})
-      @client_id = config[:client_id]          || GapIntelligence.config.client_id
+      @client_id = config[:client_id]         || GapIntelligence.config.client_id
       @client_secret = config[:client_secret] || GapIntelligence.config.client_secret
       @host = config[:host]                   || GapIntelligence.config.host
       @port = config[:port]                   || GapIntelligence.config.port
+      @scope = config[:scope]
     end
 
     # Returns the current connection to gAPI. If the connection is old or
@@ -50,9 +52,11 @@ module GapIntelligence
       raise ConfigurationError unless client_id && client_secret
 
       begin
+        client_params = {}
+        client_params[:scope] = @scope if @scope
         OAuth2::Client.new(client_id, client_secret, site: api_base_uri)
                       .client_credentials
-                      .get_token({}, 'auth_scheme' => 'request_body')
+                      .get_token(client_params, 'auth_scheme' => 'request_body')
       rescue OAuth2::Error
         raise AuthenticationError
       end

--- a/lib/gap_intelligence/configuration.rb
+++ b/lib/gap_intelligence/configuration.rb
@@ -1,6 +1,7 @@
 module GapIntelligence
   def self.configure(&block)
     yield config
+    config
   end
 
   def self.config

--- a/spec/gap/client_spec.rb
+++ b/spec/gap/client_spec.rb
@@ -80,9 +80,15 @@ describe Client do
     subject(:client) { described_class.new(client_id: 'CLIENTID', client_secret: 'ASECRET') }
 
     it 'will authenticate API calls if it provided with valid credentials' do
-        stub_api_auth('CLIENTID', 'ASECRET')
-        expect(client.connection).to be_instance_of(OAuth2::AccessToken)
-      end
+      stub_api_auth('CLIENTID', 'ASECRET')
+      expect(client.connection).to be_instance_of(OAuth2::AccessToken)
+    end
+
+    it 'will authenticate API calls if it provided with valid credentials and scope' do
+      stub_api_auth('CLIENTID', 'ASECRET', 200, scope: 'ASCOPE')
+      client = described_class.new(client_id: 'CLIENTID', client_secret: 'ASECRET', scope: 'ASCOPE')
+      expect(client.connection).to be_instance_of(OAuth2::AccessToken)
+    end
 
     it 'will raise an error if its credentials are rejected' do
       stub_api_auth('CLIENTID', 'ASECRET', 400)

--- a/spec/support/stubs.rb
+++ b/spec/support/stubs.rb
@@ -1,14 +1,16 @@
 module StubsHelper
   API_HOST = 'api.gapintelligence.com'
 
-  def stub_api_auth(client_id, client_secret, status = 200)
+  def stub_api_auth(client_id, client_secret, status = 200, options={})
+    params = {
+      client_id: client_id,
+      client_secret: client_secret,
+      grant_type: 'client_credentials'
+    }
+    params[:scope] = options[:scope] if options[:scope]
     stub_api_request(:post,
       url: 'oauth/token',
-      params: {
-        client_id: client_id,
-        client_secret: client_secret,
-        grant_type: 'client_credentials'
-      },
+      params: params,
       response: {
         access_token: 'ATOKEN',
         token_type: 'bearer',


### PR DESCRIPTION
This pull request allows to create client with specific scope.

I didn't add scope to global configuration because I thought that scope is more like local argument and may vary and depend on the reason for that client is being created.