### PR TITLE
Feature/add model specs

### DIFF
--- a/lib/gap_intelligence/client/requestable.rb
+++ b/lib/gap_intelligence/client/requestable.rb
@@ -20,7 +20,7 @@ module GapIntelligence
 
       case data
       when Array
-        objects = record_class.nil? ? data : data.collect{|object| record_class.new(object) }
+        objects = record_class.nil? ? data : data.collect{ |object| record_class.new(object) }
         RecordSet.new(objects, meta: hash.fetch('meta', {}))
       when Hash
         record_class.nil? ? data : record_class.new(data)

--- a/lib/gap_intelligence/models/brand.rb
+++ b/lib/gap_intelligence/models/brand.rb
@@ -4,8 +4,7 @@ module GapIntelligence
 
     def initialize(brand_name)
       @raw = brand_name
-      @id = brand_name
-      @attributes = {'name' => brand_name}
+      @attributes = { 'name' => brand_name }
     end
   end
 end

--- a/lib/gap_intelligence/models/record.rb
+++ b/lib/gap_intelligence/models/record.rb
@@ -9,7 +9,7 @@ module GapIntelligence
       end
       alias :attribute :attributes
 
-      def define_attribute(attr, options={})
+      def define_attribute(attr, options = {})
         klass = options[:class]
 
         define_method(attr) do

--- a/lib/gap_intelligence/models/record_set.rb
+++ b/lib/gap_intelligence/models/record_set.rb
@@ -9,7 +9,7 @@ module GapIntelligence
 
     def_delegators :@records, :each, :[], :to_ary
 
-    def initialize(records=nil, options={})
+    def initialize(records = nil, options = {})
       @records = records || []
       @meta = options[:meta]
     end

--- a/spec/factories/brands.rb
+++ b/spec/factories/brands.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :brand, class: GapIntelligence::Brand do
+  factory :brand, class: String do
     initialize_with {
       'A brand name'
     }

--- a/spec/factories/downloads.rb
+++ b/spec/factories/downloads.rb
@@ -1,33 +1,35 @@
 FactoryGirl.define do
   factory :download, class: Hash do
-    start_at "2015-11-24"
-    end_at "2016-02-23"
-    user "ccamacho@gapintelligence.com"
-    merchant_names "[]"
-    brand_names "[]"
-    file_type "csv"
-    advertisements_headers "[]"
-    pricings_headers '["Category", "Part Number", "Product", "Merchant", "Net Price", "Shelf Price", "Product Status", "On Ad", "On Promo", "Instant Savings", "Mail in Rebate", "Price Drop", "Gift Card", "Peripheral", "Bundle", "Free Gift", "Merchant Rewards", "PC Bundle", "Recycling Rebate", "Total Value", "Promotion Notes", "Instant Savings End Date", "Mail in Rebate End Date"]'
-    promotions_headers "[]"
-    custom_file_name ""
-    included_spec_headers "[]"
-    included_core_spec_headers '["Size Class", "Display Type", "Display Resolution", "Max. Refresh Rate", "Smart TV", "HDR", "Product Status"]'
-    standalone_core_spec_headers "[]"
-    standalone_spec_headers "[]"
-    status "done"
-    attachment "https://gapi.s3.amazonaws.com/uploads/download/attachment/2480/tvs-pricings-20151124-20160223.zip"
-    country_names '["United States"]'
-    product_info_fields_headers "[]"
-    category_names "TVs"
-    channels "[]"
-    pricing_date_type "raw"
-    pricing_date "date_collected"
+    start_at '2015-11-24'
+    end_at '2016-02-23'
+    created_at Time.now.to_s
+    category_names 'TVs'
+    country_names ['United States']
+    report_types ['Pricings']
+    merchant_names ['Walgreens']
+    brand_names ['HP']
+    channels []
+    pricing_date 'date_collected'
+    pricing_date_type 'raw'
+    advertisements_headers ['Category', 'Part Number', 'Product']
+    pricings_headers ['Category', 'Part Number', 'Product']
+    promotions_headers ['Category', 'Part Number', 'Product']
+    included_core_spec_headers ['Product Status', 'Display Type']
+    included_spec_headers ['Smart TV', 'HDR']
+    standalone_core_spec_headers ['WiFi', '3D']
+    standalone_spec_headers ['Launch Date', 'Width', 'Height']
+    file_type 'csv'
+    custom_file_name ''
+    status 'done'
+
+    attachment 'https://gapi.s3.amazonaws.com/uploads/download/attachment/2480/tvs-pricings-20151124-20160223.zip'
+    product_info_fields_headers []
 
     initialize_with {
       {
-        "id" => 2480,
-        "type" => "downloads",
-        "attributes" => attributes.stringify_keys
+        'id' => 2480,
+        'type' => 'downloads',
+        'attributes' => attributes.stringify_keys
       }
     }
   end

--- a/spec/gap/models/brand_spec.rb
+++ b/spec/gap/models/brand_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe GapIntelligence::Brand do
+  describe 'attributes' do
+    subject(:brand) { described_class.new build(:brand) }
+
+    it 'has name' do
+      expect(brand).to respond_to(:name)
+    end
+  end
+end

--- a/spec/gap/models/category_spec.rb
+++ b/spec/gap/models/category_spec.rb
@@ -14,5 +14,4 @@ describe GapIntelligence::Category do
       expect(category).to respond_to(:full_name)
     end
   end
-
 end

--- a/spec/gap/models/download_spec.rb
+++ b/spec/gap/models/download_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe GapIntelligence::Download do
+  include_examples 'Record'
+
+  describe 'attributes' do
+    subject(:download) { described_class.new build(:download) }
+
+    it 'has start_at as Date' do
+      expect(download.start_at).to be_an_instance_of(Date)
+    end
+
+    it 'has end_at as Date' do
+      expect(download.end_at).to be_an_instance_of(Date)
+    end
+
+    it 'has created_at as Time' do
+      expect(download.created_at).to be_an_instance_of(Time)
+    end
+
+    it 'has category_names' do
+      expect(download).to respond_to(:category_names)
+    end
+
+    it 'has country_names as Array' do
+      expect(download.country_names).to be_an_instance_of(Array)
+    end
+
+    it 'has report_types as Array' do
+      expect(download.report_types).to be_an_instance_of(Array)
+    end
+
+    it 'has merchant_names as Array' do
+      expect(download.merchant_names).to be_an_instance_of(Array)
+    end
+
+    it 'has brand_names as Array' do
+      expect(download.brand_names).to be_an_instance_of(Array)
+    end
+
+    it 'has channels as Array' do
+      expect(download.channels).to be_an_instance_of(Array)
+    end
+
+    it 'has pricing_date' do
+      expect(download).to respond_to(:pricing_date)
+    end
+
+    it 'has advertisements_headers as Array' do
+      expect(download.advertisements_headers).to be_an_instance_of(Array)
+    end
+
+    it 'has pricings_headers as Array' do
+      expect(download.pricings_headers).to be_an_instance_of(Array)
+    end
+
+    it 'has promotions_headers as Array' do
+      expect(download.promotions_headers).to be_an_instance_of(Array)
+    end
+
+    it 'has included_core_spec_headers as Array' do
+      expect(download.included_core_spec_headers).to be_an_instance_of(Array)
+    end
+
+    it 'has included_spec_headers as Array' do
+      expect(download.included_spec_headers).to be_an_instance_of(Array)
+    end
+
+    it 'has standalone_core_spec_headers as Array' do
+      expect(download.standalone_core_spec_headers).to be_an_instance_of(Array)
+    end
+
+    it 'has standalone_spec_headers as Array' do
+      expect(download.standalone_spec_headers).to be_an_instance_of(Array)
+    end
+
+    it 'has file_type' do
+      expect(download).to respond_to(:file_type)
+    end
+
+    it 'has custom_file_name' do
+      expect(download).to respond_to(:custom_file_name)
+    end
+
+    it 'has status' do
+      expect(download).to respond_to(:status)
+    end
+  end
+end

--- a/spec/gap/models/header_spec.rb
+++ b/spec/gap/models/header_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe GapIntelligence::Header do
+  include_examples 'Record'
+
+  describe 'attributes' do
+    subject(:header) { described_class.new build(:header) }
+
+    it 'has name' do
+      expect(header).to respond_to(:name)
+    end
+
+    it 'has unit' do
+      expect(header).to respond_to(:unit)
+    end
+
+    it 'has core_header' do
+      expect(header).to respond_to(:core_header)
+    end
+
+    it 'has position' do
+      expect(header).to respond_to(:position)
+    end
+  end
+end

--- a/spec/gap/models/merchant_spec.rb
+++ b/spec/gap/models/merchant_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe GapIntelligence::Merchant do
+  include_examples 'Record'
+
+  describe 'attributes' do
+    subject(:merchant) { described_class.new build(:merchant) }
+
+    it 'has name' do
+      expect(merchant).to respond_to(:name)
+    end
+
+    it 'has merchant_type' do
+      expect(merchant).to respond_to(:merchant_type)
+    end
+
+    it 'has channel' do
+      expect(merchant).to respond_to(:channel)
+    end
+
+    it 'has country_code' do
+      expect(merchant).to respond_to(:country_code)
+    end
+  end
+end

--- a/spec/gap/models/record_set_spec.rb
+++ b/spec/gap/models/record_set_spec.rb
@@ -22,5 +22,4 @@ describe GapIntelligence::RecordSet do
   it 'responds to to_ary' do
     expect(record_set).to respond_to(:to_ary)
   end
-
 end

--- a/spec/support/record_shared.rb
+++ b/spec/support/record_shared.rb
@@ -5,6 +5,18 @@ shared_examples_for 'Record' do
     expect(described_class).to respond_to(:new)
   end
 
+  describe 'attr_reader' do
+    subject(:record) { described_class.new }
+
+    it 'has id' do
+      expect(record).to respond_to(:id)
+    end
+
+    it 'has raw' do
+      expect(record).to respond_to(:raw)
+    end
+  end
+
   describe '.attributes' do
     let(:hash) { {
       'name' => 'Name 1',

--- a/spec/support/stubs.rb
+++ b/spec/support/stubs.rb
@@ -1,7 +1,7 @@
 module StubsHelper
   API_HOST = 'api.gapintelligence.com'
 
-  def stub_api_auth(client_id, client_secret, status = 200, options={})
+  def stub_api_auth(client_id, client_secret, status = 200, options = {})
     params = {
       client_id: client_id,
       client_secret: client_secret,


### PR DESCRIPTION
Specs for download, header, merchant and brand models. Brand specs look different since endpoint returns brands as array, different from other endpoints. Once we move brands into an entity, brand model would have to change here and we would be able to use same schema for it's specs. I could move record_shared specs to brand specs for the sake of having them, but decided to leave it that way for now, open for discussion; open to merge only download, merchant and header models