### PR TITLE
Remove variants in MPT

### DIFF
--- a/lib/gap_intelligence/models/merchant_pricing_trend.rb
+++ b/lib/gap_intelligence/models/merchant_pricing_trend.rb
@@ -1,11 +1,4 @@
 module GapIntelligence
   class MerchantPricingTrend < Record
-    def variants
-      @variants ||= begin
-        parsed = MultiJson.load(raw[:response_body]) rescue {}
-        data = parsed.fetch('data', {})
-        data['variants']
-      end
-    end
   end
 end

--- a/spec/gap/models/merchant_pricing_trend_spec.rb
+++ b/spec/gap/models/merchant_pricing_trend_spec.rb
@@ -16,10 +16,4 @@ describe GapIntelligence::MerchantPricingTrend do
       expect(merchant_pricing_trend.raw[:response_body]).to eq response_body
     end
   end
-
-  describe 'methods' do
-    it 'returns parsed variants from response body' do
-      expect(merchant_pricing_trend.variants).to eq merchant_pricing_trend_data['variants']
-    end
-  end
 end


### PR DESCRIPTION
It is not longer necessary to have `variants` method in MPT model.