### PR TITLE
update error message handling

### DIFF
--- a/lib/gap_intelligence/client/requestable.rb
+++ b/lib/gap_intelligence/client/requestable.rb
@@ -14,7 +14,7 @@ module GapIntelligence
 
       response = connection.request(method, path, options, &block)
 
-      return RequestError.new(response.parsed['error']) if response.error
+      return RequestError.new(parse_error_message(response)) if response.error
       return instantiate_record(record_class, response_body: response.body) if options[:init_with_response_body]
 
       hash = response.parsed
@@ -40,6 +40,14 @@ module GapIntelligence
 
     def build_resource_path(*path)
       URI.parse(path.join('/')).path
+    end
+
+    def parse_error_message(response)
+      if response.parsed && response.parsed['error']
+        response.parsed['error']
+      else
+        response.error
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is to protect us from times where the API may potentially timeout or throw a very random error. When these random issues occur, the response hash will never have the error key, so that causes this to occur. 

```undefined method `[]' for nil:NilClass```

However, the response.error will hopefully reveal what the heck really happened. So this will check for the presence of the error key in the hash first and fallback to just dumping the ```response.error``` into the ```RequestError``` api object.