### PR TITLE
Add created_at attribute to MPT download

### DIFF
--- a/lib/gap_intelligence/models/merchant_pricing_trend_download.rb
+++ b/lib/gap_intelligence/models/merchant_pricing_trend_download.rb
@@ -8,5 +8,6 @@ module GapIntelligence
     attributes :min_price, :max_price
     attributes :specs
     attributes :custom_file_name, :status
+    attribute :created_at, class: Time
   end
 end

--- a/spec/factories/merchant_pricing_trend_downloads.rb
+++ b/spec/factories/merchant_pricing_trend_downloads.rb
@@ -21,6 +21,8 @@ FactoryGirl.define do
     custom_file_name ''
     status 'done'
 
+    created_at { Time.now.to_s }
+
     initialize_with {
       {
         'id' => 2480,

--- a/spec/gap/models/merchant_pricing_trend_download_spec.rb
+++ b/spec/gap/models/merchant_pricing_trend_download_spec.rb
@@ -65,5 +65,9 @@ describe GapIntelligence::MerchantPricingTrendDownload do
     it 'has status' do
       expect(download).to respond_to(:status)
     end
+
+    it 'has created_at as Time' do
+      expect(download.created_at).to be_an_instance_of(Time)
+    end
   end
 end


### PR DESCRIPTION
This pull request adds `created_at` attribute to MPT download.
