### PR TITLE
Update perform_request to raise errors

### DIFF
--- a/lib/gap_intelligence/client.rb
+++ b/lib/gap_intelligence/client.rb
@@ -28,7 +28,8 @@ module GapIntelligence
                   :port,
                   :use_ssl,
                   :scope,
-                  :connection_build
+                  :connection_build,
+                  :raise_errors
 
     def initialize(config = {}, &block)
       @client_id = config[:client_id]         || GapIntelligence.config.client_id
@@ -38,6 +39,7 @@ module GapIntelligence
       @use_ssl = config[:use_ssl]             || GapIntelligence.config.use_ssl
       @scope = config[:scope]
       @connection_build = block               || GapIntelligence.config.connection_build
+      @raise_errors = config[:raise_errors]   || GapIntelligence.config.raise_errors
     end
 
     # Returns the current connection to gAPI. If the connection is old or

--- a/lib/gap_intelligence/client/requestable.rb
+++ b/lib/gap_intelligence/client/requestable.rb
@@ -6,6 +6,7 @@ module GapIntelligence
     # @param [String] path URL path of request
     # @param [Hash] options the options to make the request with
     # @yield [req] The Faraday request
+    # @raise [RequestError] If raise_errors set true and request fails for any reason
     def perform_request(method, path, options = {}, &block)
       record_class = options.delete(:record_class)
       raise_error = options.fetch(:raise_errors, raise_errors)

--- a/lib/gap_intelligence/client/requestable.rb
+++ b/lib/gap_intelligence/client/requestable.rb
@@ -8,15 +8,16 @@ module GapIntelligence
     # @yield [req] The Faraday request
     def perform_request(method, path, options = {}, &block)
       record_class = options.delete(:record_class)
+      raise_error = options.fetch(:raise_errors, raise_errors)
       options[:headers] = headers
-      options[:raise_errors] = options.fetch(:raise_errors, raise_errors)
+      options[:raise_errors] = false
       options[:init_with_response_body] = options.fetch(:init_with_response_body, false)
 
       response = connection.request(method, path, options, &block)
 
       if response.error
         error = RequestError.new(parse_error_message(response))
-        raise(error) if options[:raise_errors]
+        raise(error) if raise_error
         return nil
       end
 

--- a/lib/gap_intelligence/client/requestable.rb
+++ b/lib/gap_intelligence/client/requestable.rb
@@ -9,7 +9,7 @@ module GapIntelligence
     def perform_request(method, path, options = {}, &block)
       record_class = options.delete(:record_class)
       options[:headers] = headers
-      options[:raise_errors] = options.fetch(:raise_errors, false)
+      options[:raise_errors] = options.fetch(:raise_errors, raise_errors)
       options[:init_with_response_body] = options.fetch(:init_with_response_body, false)
 
       response = connection.request(method, path, options, &block)

--- a/lib/gap_intelligence/configuration.rb
+++ b/lib/gap_intelligence/configuration.rb
@@ -19,12 +19,14 @@ module GapIntelligence
                   :host,
                   :port,
                   :use_ssl,
-                  :connection_build
+                  :connection_build,
+                  :raise_errors
 
     def initialize
       @host = 'api.gapintelligence.com'
       @port = 443
       @use_ssl = true
+      @raise_errors = false
     end
   end
 end

--- a/spec/gap/client/downloads_spec.rb
+++ b/spec/gap/client/downloads_spec.rb
@@ -20,11 +20,10 @@ describe GapIntelligence::Downloads do
       expect(result).to be_instance_of Download
     end
 
-    it 'returns error messages if parameters are not valid' do
+    it 'returns nil if parameters are not valid' do
       stub_api_request(:post, url: 'downloads', response: { error: 'error message' }, status: 422)
 
-      expect(result).to be_instance_of RequestError
-      expect(result.message).to eq('error message')
+      expect(result).to be_nil
     end
   end
 
@@ -83,11 +82,10 @@ describe GapIntelligence::Downloads do
       expect(result).to eq(nil)
     end
 
-    it 'returns error messages if there is no such download.' do
+    it 'returns nil if there is no such download.' do
       stub_api_request(:delete, url: 'downloads', response: { error: 'error message' }, status: 404)
 
-      expect(result).to be_instance_of RequestError
-      expect(result.message).to eq('error message')
+      expect(result).to be_nil
     end
   end
 end

--- a/spec/gap/client/merchant_pricing_trend_downloads_spec.rb
+++ b/spec/gap/client/merchant_pricing_trend_downloads_spec.rb
@@ -20,11 +20,10 @@ describe GapIntelligence::MerchantPricingTrendDownloads do
       expect(result).to be_instance_of MerchantPricingTrendDownload
     end
 
-    it 'returns error messages if parameters are not valid' do
+    it 'returns nil if parameters are not valid' do
       stub_api_request(:post, url: 'merchant_pricing_trend_downloads', response: { error: 'error message' }, status: 422)
 
-      expect(result).to be_instance_of RequestError
-      expect(result.message).to eq('error message')
+      expect(result).to be_nil
     end
   end
 
@@ -67,11 +66,10 @@ describe GapIntelligence::MerchantPricingTrendDownloads do
       expect(result).to eq(nil)
     end
 
-    it 'returns error messages if there is no such merchant pricing trend download.' do
+    it 'returns nil if there is no such merchant pricing trend download.' do
       stub_api_request(:delete, url: 'merchant_pricing_trend_downloads', response: { error: 'error message' }, status: 404)
 
-      expect(result).to be_instance_of RequestError
-      expect(result.message).to eq('error message')
+      expect(result).to be_nil
     end
   end
 end

--- a/spec/gap/client/requestable_spec.rb
+++ b/spec/gap/client/requestable_spec.rb
@@ -64,7 +64,7 @@ describe GapIntelligence::Requestable do
 
         it 'raises error' do
           expect {
-            client.perform_request(:get, 'path', raise_errors: true)
+            client.perform_request(:get, 'path')
           }.to raise_error(RequestError)
         end
       end

--- a/spec/gap/client/requestable_spec.rb
+++ b/spec/gap/client/requestable_spec.rb
@@ -41,5 +41,33 @@ describe GapIntelligence::Requestable do
         expect(record_set).to be_instance_of(GapIntelligence::Record)
       end
     end
+
+    context 'with error' do
+      before { stub_api_request(:get, response: { error: 'error message' }, status: 404) }
+
+      it 'raises error when raise_errors is true' do
+        expect {
+          client.perform_request(:get, 'path', raise_errors: true)
+        }.to raise_error(RequestError)
+      end
+
+      it 'returns nil when raise_errors is false' do
+        expect(client.perform_request(:get, 'path', raise_errors: false)).to be_nil
+      end
+
+      it 'returns nil when raise_errors is not defined' do
+        expect(client.perform_request(:get, 'path')).to be_nil
+      end
+
+      context 'when raise_errors set globaly' do
+        subject(:client) { GapIntelligence::Client.new(client_id: 'CLIENTID', client_secret: 'ASECRET', raise_errors: true) }
+
+        it 'raises error' do
+          expect {
+            client.perform_request(:get, 'path', raise_errors: true)
+          }.to raise_error(RequestError)
+        end
+      end
+    end
   end
 end

--- a/spec/gap/configuration_spec.rb
+++ b/spec/gap/configuration_spec.rb
@@ -30,4 +30,18 @@ describe Configuration do
       it { expect(config.client_secret).to eq('CLIENT_SECRET') }
     end
   end
+
+  describe 'raise_errors' do
+    context 'by default' do
+      it { expect(config.raise_errors).to be_falsey }
+    end
+
+    context 'configured via config block' do
+      before {
+        GapIntelligence.configure {|c| c.raise_errors = true }
+      }
+
+      it { expect(config.raise_errors).to be_truthy }
+    end
+  end
 end


### PR DESCRIPTION
This pull request updates `perform_request` to raise errors instead of returning error.

`raise_errors` option can be configured globally through `config {}` or pass as an option to api methods. By default `raise_errors` is false, if error happens, `nil` will be returned as a result. When `raise_errors` is true, `RequestError` will be raised.